### PR TITLE
Refactor/extract modules

### DIFF
--- a/source/shelly-1-gen4/light/main/app_driver.cpp
+++ b/source/shelly-1-gen4/light/main/app_driver.cpp
@@ -21,7 +21,6 @@
 #include <freertos/task.h>
 #include <freertos/queue.h>
 #include <device.h>
-#include <button_gpio.h>
 
 using namespace chip::app::Clusters;
 using namespace esp_matter;
@@ -32,7 +31,6 @@ extern uint16_t light_endpoint_id;
 // Shelly 1 Gen4 GPIO assignments
 #define RELAY_GPIO          GPIO_NUM_5
 #define SWITCH_INPUT_GPIO   GPIO_NUM_10
-#define BUTTON_GPIO         GPIO_NUM_4
 
 // Temperature protection
 #define TEMP_TRIP_CELSIUS   75.0f
@@ -117,21 +115,6 @@ static void app_driver_switch_task(void *arg)
     }
 }
 
-static void app_driver_button_toggle_cb(void *arg, void *data)
-{
-    ESP_LOGI(TAG, "Toggle button pressed");
-    uint16_t endpoint_id = light_endpoint_id;
-    uint32_t cluster_id = OnOff::Id;
-    uint32_t attribute_id = OnOff::Attributes::OnOff::Id;
-
-    attribute_t *attribute = attribute::get(endpoint_id, cluster_id, attribute_id);
-
-    esp_matter_attr_val_t val = esp_matter_invalid(NULL);
-    attribute::get_val(attribute, &val);
-    val.val.b = !val.val.b;
-    attribute::update(endpoint_id, cluster_id, attribute_id, &val);
-}
-
 esp_err_t app_driver_attribute_update(app_driver_handle_t driver_handle, uint16_t endpoint_id, uint32_t cluster_id,
                                       uint32_t attribute_id, esp_matter_attr_val_t *val)
 {
@@ -214,24 +197,4 @@ app_driver_handle_t app_driver_light_init()
     }
 
     return (app_driver_handle_t)1;
-}
-
-app_driver_handle_t app_driver_button_init()
-{
-    button_handle_t handle = NULL;
-    const button_config_t btn_cfg = {0};
-
-    // Hardcoded GPIO4 for Shelly 1 Gen4 device button
-    const button_gpio_config_t btn_gpio_cfg = {
-        .gpio_num = GPIO_NUM_4,
-        .active_level = 0,
-    };
-
-    if (iot_button_new_gpio_device(&btn_cfg, &btn_gpio_cfg, &handle) != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to create button device");
-        return NULL;
-    }
-
-    iot_button_register_cb(handle, BUTTON_PRESS_DOWN, NULL, app_driver_button_toggle_cb, NULL);
-    return (app_driver_handle_t)handle;
 }

--- a/source/shelly-1-gen4/light/main/app_driver.cpp
+++ b/source/shelly-1-gen4/light/main/app_driver.cpp
@@ -7,34 +7,17 @@
 */
 
 #include <esp_log.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include <esp_matter.h>
 #include <app_priv.h>
 #include <common_macros.h>
-#include <driver/gpio.h>
-#include <device.h>
-#include <thermal.h>
+
+#include <relay.h>
 
 using namespace chip::app::Clusters;
 using namespace esp_matter;
 
-static const char *TAG = "app_driver";
 extern uint16_t light_endpoint_id;
-
-// Shelly 1 Gen4 GPIO assignments
-#define RELAY_GPIO          GPIO_NUM_5
-
-static esp_err_t app_driver_relay_set_power(bool power)
-{
-    if (thermal_is_faulted() && power) {
-        ESP_LOGW(TAG, "Thermal fault active relay turn on blocked");
-        return ESP_ERR_INVALID_STATE;
-    }
-    ESP_LOGI(TAG, "Setting relay: %s", power ? "ON" : "OFF");
-    return gpio_set_level(RELAY_GPIO, power ? 1 : 0);
-}
 
 esp_err_t app_driver_attribute_update(app_driver_handle_t driver_handle, uint16_t endpoint_id, uint32_t cluster_id,
                                       uint32_t attribute_id, esp_matter_attr_val_t *val)
@@ -43,7 +26,7 @@ esp_err_t app_driver_attribute_update(app_driver_handle_t driver_handle, uint16_
     if (endpoint_id == light_endpoint_id) {
         if (cluster_id == OnOff::Id) {
             if (attribute_id == OnOff::Attributes::OnOff::Id) {
-                err = app_driver_relay_set_power(val->val.b);
+                err = relay_set(val->val.b);
             }
         }
     }
@@ -57,43 +40,7 @@ esp_err_t app_driver_light_set_defaults(uint16_t endpoint_id)
 
     attribute_t *attribute = attribute::get(endpoint_id, OnOff::Id, OnOff::Attributes::OnOff::Id);
     attribute::get_val(attribute, &val);
-    err = app_driver_relay_set_power(val.val.b);
+    err = relay_set(val.val.b);
 
     return err;
-}
-
-app_driver_handle_t app_driver_light_init()
-{
-    // Initialize relay GPIO
-    gpio_config_t relay_cfg = {
-        .pin_bit_mask = (1ULL << RELAY_GPIO),
-        .mode = GPIO_MODE_OUTPUT,
-        .pull_up_en = GPIO_PULLUP_DISABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        .intr_type = GPIO_INTR_DISABLE,
-    };
-    gpio_config(&relay_cfg);
-    gpio_set_level(RELAY_GPIO, 0);
-
-    return (app_driver_handle_t)1;
-}
-// Temporary shim used by the thermal monitor (thermal.cpp) until the
-// relay code is extracted into its own module. When relay extraction is
-// complete, this function should be deleted and thermal.cpp should call
-// relay_set(false) directly.
-void app_driver_force_relay_off(void)
-{
-    // 1. Direct hardware: drive relay GPIO low. This bypasses every
-    //    layer above the GPIO peripheral and ensures the relay
-    //    physically de-energizes regardless of Matter stack state.
-    gpio_set_level(RELAY_GPIO, 0);
-
-    // 2. Update Matter attribute so connected ecosystems see the change.
-    //    This will trigger the attribute callback, which would normally
-    //    call app_driver_relay_set_power(false), but the GPIO is already
-    //    off so that's a no-op.
-    uint32_t cluster_id = OnOff::Id;
-    uint32_t attribute_id = OnOff::Attributes::OnOff::Id;
-    esp_matter_attr_val_t val = esp_matter_bool(false);
-    attribute::update(light_endpoint_id, cluster_id, attribute_id, &val);
 }

--- a/source/shelly-1-gen4/light/main/app_driver.cpp
+++ b/source/shelly-1-gen4/light/main/app_driver.cpp
@@ -13,14 +13,12 @@
 #include <esp_matter.h>
 #include <app_priv.h>
 #include <common_macros.h>
-
 #include <driver/gpio.h>
-#include <driver/temperature_sensor.h>
-#include <esp_timer.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <freertos/queue.h>
 #include <device.h>
+#include <thermal.h>
 
 using namespace chip::app::Clusters;
 using namespace esp_matter;
@@ -32,51 +30,12 @@ extern uint16_t light_endpoint_id;
 #define RELAY_GPIO          GPIO_NUM_5
 #define SWITCH_INPUT_GPIO   GPIO_NUM_10
 
-// Temperature protection
-#define TEMP_TRIP_CELSIUS   75.0f
-#define TEMP_SUSTAINED_MS   10000
-
-static temperature_sensor_handle_t temp_sensor = NULL;
-static int64_t over_temp_start_ms = 0;
-static bool thermal_fault = false;
-
 // Switch input queue
 static QueueHandle_t switch_evt_queue = NULL;
 
-static esp_err_t app_driver_relay_set_power(bool power);
-
-static void app_driver_temp_check()
-{
-    float temp = 0;
-    esp_err_t err = temperature_sensor_get_celsius(temp_sensor, &temp);
-    if (err != ESP_OK) return;
-
-    ESP_LOGD(TAG, "Board temp: %.1f C", temp);
-
-    if (temp > TEMP_TRIP_CELSIUS) {
-        if (over_temp_start_ms == 0) {
-            over_temp_start_ms = esp_timer_get_time() / 1000;
-        } else {
-            int64_t elapsed = (esp_timer_get_time() / 1000) - over_temp_start_ms;
-            if (elapsed >= TEMP_SUSTAINED_MS && !thermal_fault) {
-                ESP_LOGE(TAG, "Thermal fault! Temp: %.1f C shutting off relay", temp);
-                thermal_fault = true;
-                app_driver_relay_set_power(false);
-                uint32_t cluster_id = OnOff::Id;
-                uint32_t attribute_id = OnOff::Attributes::OnOff::Id;
-                esp_matter_attr_val_t val = esp_matter_bool(false);
-                attribute::update(light_endpoint_id, cluster_id, attribute_id, &val);
-            }
-        }
-    } else {
-        over_temp_start_ms = 0;
-        thermal_fault = false;
-    }
-}
-
 static esp_err_t app_driver_relay_set_power(bool power)
 {
-    if (thermal_fault && power) {
+    if (thermal_is_faulted() && power) {
         ESP_LOGW(TAG, "Thermal fault active relay turn on blocked");
         return ESP_ERR_INVALID_STATE;
     }
@@ -154,22 +113,6 @@ app_driver_handle_t app_driver_light_init()
     gpio_config(&relay_cfg);
     gpio_set_level(RELAY_GPIO, 0);
 
-    // Initialize internal temperature sensor
-    temperature_sensor_config_t temp_cfg = {
-        .range_min = 20,
-        .range_max = 100,
-    };
-    temperature_sensor_install(&temp_cfg, &temp_sensor);
-    temperature_sensor_enable(temp_sensor);
-
-    // Start temperature monitoring task
-    xTaskCreate([](void *arg) {
-        while (true) {
-            app_driver_temp_check();
-            vTaskDelay(pdMS_TO_TICKS(2000));
-        }
-    }, "temp_monitor", 2048, NULL, 5, NULL);
-
     // Initialize external switch input GPIO10
     // NOTE: GPIO_PULLUP_DISABLE required — Shelly PCB has external pull resistor on GPIO10.
     // Internal pullup fights the external circuit and prevents ISR from firing.
@@ -197,4 +140,24 @@ app_driver_handle_t app_driver_light_init()
     }
 
     return (app_driver_handle_t)1;
+}
+// Temporary shim used by the thermal monitor (thermal.cpp) until the
+// relay code is extracted into its own module. When relay extraction is
+// complete, this function should be deleted and thermal.cpp should call
+// relay_set(false) directly.
+void app_driver_force_relay_off(void)
+{
+    // 1. Direct hardware: drive relay GPIO low. This bypasses every
+    //    layer above the GPIO peripheral and ensures the relay
+    //    physically de-energizes regardless of Matter stack state.
+    gpio_set_level(RELAY_GPIO, 0);
+
+    // 2. Update Matter attribute so connected ecosystems see the change.
+    //    This will trigger the attribute callback, which would normally
+    //    call app_driver_relay_set_power(false), but the GPIO is already
+    //    off so that's a no-op.
+    uint32_t cluster_id = OnOff::Id;
+    uint32_t attribute_id = OnOff::Attributes::OnOff::Id;
+    esp_matter_attr_val_t val = esp_matter_bool(false);
+    attribute::update(light_endpoint_id, cluster_id, attribute_id, &val);
 }

--- a/source/shelly-1-gen4/light/main/app_driver.cpp
+++ b/source/shelly-1-gen4/light/main/app_driver.cpp
@@ -14,9 +14,6 @@
 #include <app_priv.h>
 #include <common_macros.h>
 #include <driver/gpio.h>
-#include <freertos/FreeRTOS.h>
-#include <freertos/task.h>
-#include <freertos/queue.h>
 #include <device.h>
 #include <thermal.h>
 
@@ -28,10 +25,6 @@ extern uint16_t light_endpoint_id;
 
 // Shelly 1 Gen4 GPIO assignments
 #define RELAY_GPIO          GPIO_NUM_5
-#define SWITCH_INPUT_GPIO   GPIO_NUM_10
-
-// Switch input queue
-static QueueHandle_t switch_evt_queue = NULL;
 
 static esp_err_t app_driver_relay_set_power(bool power)
 {
@@ -41,37 +34,6 @@ static esp_err_t app_driver_relay_set_power(bool power)
     }
     ESP_LOGI(TAG, "Setting relay: %s", power ? "ON" : "OFF");
     return gpio_set_level(RELAY_GPIO, power ? 1 : 0);
-}
-
-static void IRAM_ATTR app_driver_switch_isr(void *arg)
-{
-    uint32_t gpio_num = SWITCH_INPUT_GPIO;
-    xQueueSendFromISR(switch_evt_queue, &gpio_num, NULL);
-}
-
-static void app_driver_switch_task(void *arg)
-{
-    while (true) {
-        uint32_t io_num;
-        if (xQueueReceive(switch_evt_queue, &io_num, portMAX_DELAY)) {
-            // 50ms debounce
-            vTaskDelay(pdMS_TO_TICKS(50));
-
-            // Drain any additional events during debounce
-            while (xQueueReceive(switch_evt_queue, &io_num, 0) == pdTRUE) {}
-
-            uint16_t endpoint_id = light_endpoint_id;
-            uint32_t cluster_id = OnOff::Id;
-            uint32_t attribute_id = OnOff::Attributes::OnOff::Id;
-
-            attribute_t *attribute = attribute::get(endpoint_id, cluster_id, attribute_id);
-            esp_matter_attr_val_t val = esp_matter_invalid(NULL);
-            attribute::get_val(attribute, &val);
-            val.val.b = !val.val.b;
-            attribute::update(endpoint_id, cluster_id, attribute_id, &val);
-            ESP_LOGI(TAG, "Switch input toggled relay");
-        }
-    }
 }
 
 esp_err_t app_driver_attribute_update(app_driver_handle_t driver_handle, uint16_t endpoint_id, uint32_t cluster_id,
@@ -112,32 +74,6 @@ app_driver_handle_t app_driver_light_init()
     };
     gpio_config(&relay_cfg);
     gpio_set_level(RELAY_GPIO, 0);
-
-    // Initialize external switch input GPIO10
-    // NOTE: GPIO_PULLUP_DISABLE required — Shelly PCB has external pull resistor on GPIO10.
-    // Internal pullup fights the external circuit and prevents ISR from firing.
-    switch_evt_queue = xQueueCreate(10, sizeof(uint32_t));
-    xTaskCreate(app_driver_switch_task, "switch_task", 4096, NULL, 10, NULL);
-
-    gpio_config_t switch_cfg = {
-        .pin_bit_mask = (1ULL << SWITCH_INPUT_GPIO),
-        .mode = GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_DISABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        .intr_type = GPIO_INTR_ANYEDGE,
-    };
-    gpio_config(&switch_cfg);
-
-    // ISR service may already be installed by Matter stack
-    esp_err_t isr_err = gpio_install_isr_service(0);
-    if (isr_err != ESP_OK && isr_err != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE(TAG, "Failed to install ISR service: %d", isr_err);
-    }
-
-    esp_err_t handler_err = gpio_isr_handler_add(SWITCH_INPUT_GPIO, app_driver_switch_isr, NULL);
-    if (handler_err != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to add switch ISR handler: %d", handler_err);
-    }
 
     return (app_driver_handle_t)1;
 }

--- a/source/shelly-1-gen4/light/main/app_main.cpp
+++ b/source/shelly-1-gen4/light/main/app_main.cpp
@@ -183,7 +183,7 @@ static esp_err_t app_identification_cb(identification::callback_type_t type, uin
 
     case identification::callback_type_t::EFFECT:
         // TriggerEffect command - effect_id specifies which effect.
-        // For v1.2.0 we treat all effects as basic identify blink.
+        // All effects currently map to the basic identify blink.
         ESP_LOGI(TAG, "Identify EFFECT %u variant %u - using default blink", effect_id, effect_variant);
         status_led_start_identify();
         break;
@@ -225,11 +225,10 @@ extern "C" void app_main()
 
     MEMORY_PROFILER_DUMP_HEAP_STAT("Bootup");
 
-     // Initialize subsystems. Order matters for safety:
-     // relay first so the GPIO is in known-safe state before anything else.
-     // thermal second so overtemp protection is active as early as possible.
-     // switch_input and button last for user-facing inputs.
-     
+    // Initialize subsystems. Order matters for safety:
+    // relay first so the GPIO is in known-safe state before anything else.
+    // thermal second so overtemp protection is active as early as possible.
+    // switch_input and button last for user-facing inputs.
     relay_init();
     thermal_init();
     switch_input_init();

--- a/source/shelly-1-gen4/light/main/app_main.cpp
+++ b/source/shelly-1-gen4/light/main/app_main.cpp
@@ -20,6 +20,7 @@
 #include <app_priv.h>
 #include <app_reset.h>
 #include "status_led.h"
+#include "button.h"
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/ESP32/OpenthreadLauncher.h>
 #endif
@@ -223,7 +224,7 @@ extern "C" void app_main()
 
     /* Initialize driver */
     app_driver_handle_t light_handle = app_driver_light_init();
-    app_driver_handle_t button_handle = app_driver_button_init();
+    shelly_button_handle_t button_handle = button_init();
     app_reset_button_register(button_handle);
 
     /* Create a Matter node and add the mandatory Root Node device type on endpoint 0 */

--- a/source/shelly-1-gen4/light/main/app_main.cpp
+++ b/source/shelly-1-gen4/light/main/app_main.cpp
@@ -23,6 +23,7 @@
 #include <button.h>
 #include <thermal.h>
 #include <switch_input.h>
+#include <relay.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/ESP32/OpenthreadLauncher.h>
 #endif
@@ -108,8 +109,8 @@ static void app_event_cb(const ChipDeviceEvent *event, intptr_t arg)
         ESP_LOGI(TAG, "Commissioning window opened");
         MEMORY_PROFILER_DUMP_HEAP_STAT("commissioning window opened");
         // Only show BLE advertising LED if device is truly uncommissioned.
-        // Commissioned devices may open windows for Multi-Admin pairing —
-        // in that case, preserve the connected state to avoid confusing users.
+        // Commissioned devices may open windows for Multi-Admin pairing.
+        // In that case, preserve the connected state to avoid confusing users.
         if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0) {
             status_led_set_state(LED_STATE_BLE_ADVERTISING);
         } else {
@@ -127,7 +128,7 @@ static void app_event_cb(const ChipDeviceEvent *event, intptr_t arg)
             chip::CommissioningWindowManager  &commissionMgr = chip::Server::GetInstance().GetCommissioningWindowManager();
             constexpr auto kTimeoutSeconds = chip::System::Clock::Seconds16(k_timeout_seconds);
             if (!commissionMgr.IsCommissioningWindowOpen()) {
-                /* After removing last fabric, re-open commissioning window via DNS-SD */
+                // After removing last fabric, re-open commissioning window via DNS-SD
                 CHIP_ERROR err = commissionMgr.OpenBasicCommissioningWindow(kTimeoutSeconds,
                                                                             chip::CommissioningWindowAdvertisement::kDnssdOnly);
                 if (err != CHIP_NO_ERROR) {
@@ -216,22 +217,26 @@ extern "C" void app_main()
 {
     esp_err_t err = ESP_OK;
 
-    /* Initialize the ESP NVS layer */
+    // Initialize the ESP NVS layer
     nvs_flash_init();
 
-    /* Initialize status LED */
+    // Initialize status LED
     status_led_init();
 
     MEMORY_PROFILER_DUMP_HEAP_STAT("Bootup");
 
-    /* Initialize driver */
-    app_driver_handle_t light_handle = app_driver_light_init();
+     // Initialize subsystems. Order matters for safety:
+     // relay first so the GPIO is in known-safe state before anything else.
+     // thermal second so overtemp protection is active as early as possible.
+     // switch_input and button last for user-facing inputs.
+     
+    relay_init();
     thermal_init();
     switch_input_init();
     shelly_button_handle_t button_handle = button_init();
     app_reset_button_register(button_handle);
 
-    /* Create a Matter node and add the mandatory Root Node device type on endpoint 0 */
+    // Create a Matter node and add the mandatory Root Node device type on endpoint 0
     node::config_t node_config;
 
     // node handle can be used to add/modify other endpoints.
@@ -244,7 +249,7 @@ extern "C" void app_main()
     light_config.on_off.on_off = DEFAULT_POWER;
 
     // endpoint handles can be used to add/modify clusters.
-    endpoint_t *endpoint = on_off_light::create(node, &light_config, ENDPOINT_FLAG_NONE, light_handle);
+    endpoint_t *endpoint = on_off_light::create(node, &light_config, ENDPOINT_FLAG_NONE, nullptr);
     ABORT_APP_ON_FAILURE(endpoint != nullptr, ESP_LOGE(TAG, "Failed to create on_off_light endpoint"));
 
     light_endpoint_id = endpoint::get_id(endpoint);
@@ -258,7 +263,7 @@ extern "C" void app_main()
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    /* Set OpenThread platform config */
+    // Set OpenThread platform config
     esp_openthread_platform_config_t config = {
         .radio_config = ESP_OPENTHREAD_DEFAULT_RADIO_CONFIG(),
         .host_config = ESP_OPENTHREAD_DEFAULT_HOST_CONFIG(),
@@ -276,13 +281,13 @@ extern "C" void app_main()
 #endif
 #endif // CONFIG_ENABLE_SET_CERT_DECLARATION_API
 
-    /* Matter start */
+    // Matter start
     err = esp_matter::start(app_event_cb);
     ABORT_APP_ON_FAILURE(err == ESP_OK, ESP_LOGE(TAG, "Failed to start Matter, err:%d", err));
 
     MEMORY_PROFILER_DUMP_HEAP_STAT("matter started");
 
-    /* Starting driver with default values */
+    // Starting driver with default values
     app_driver_light_set_defaults(light_endpoint_id);
 
 #if CONFIG_ENABLE_ENCRYPTED_OTA

--- a/source/shelly-1-gen4/light/main/app_main.cpp
+++ b/source/shelly-1-gen4/light/main/app_main.cpp
@@ -22,6 +22,7 @@
 #include <status_led.h>
 #include <button.h>
 #include <thermal.h>
+#include <switch_input.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/ESP32/OpenthreadLauncher.h>
 #endif
@@ -226,6 +227,7 @@ extern "C" void app_main()
     /* Initialize driver */
     app_driver_handle_t light_handle = app_driver_light_init();
     thermal_init();
+    switch_input_init();
     shelly_button_handle_t button_handle = button_init();
     app_reset_button_register(button_handle);
 

--- a/source/shelly-1-gen4/light/main/app_main.cpp
+++ b/source/shelly-1-gen4/light/main/app_main.cpp
@@ -19,8 +19,9 @@
 
 #include <app_priv.h>
 #include <app_reset.h>
-#include "status_led.h"
-#include "button.h"
+#include <status_led.h>
+#include <button.h>
+#include <thermal.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/ESP32/OpenthreadLauncher.h>
 #endif
@@ -224,6 +225,7 @@ extern "C" void app_main()
 
     /* Initialize driver */
     app_driver_handle_t light_handle = app_driver_light_init();
+    thermal_init();
     shelly_button_handle_t button_handle = button_init();
     app_reset_button_register(button_handle);
 

--- a/source/shelly-1-gen4/light/main/app_priv.h
+++ b/source/shelly-1-gen4/light/main/app_priv.h
@@ -15,59 +15,36 @@
 #include "esp_openthread_types.h"
 #endif
 
-/** Default attribute values used during initialization */
+// Default attribute values used during initialization
 #define DEFAULT_POWER false
 
 typedef void *app_driver_handle_t;
 
-/** Initialize the light driver
- *
- * This initializes the light driver associated with the selected board.
- *
- * @return Handle on success.
- * @return NULL in case of failure.
- */
-app_driver_handle_t app_driver_light_init();
-
-/** Driver Update
- *
- * This API should be called to update the driver for the attribute being updated.
- * This is usually called from the common `app_attribute_update_cb()`.
- *
- * @param[in] endpoint_id Endpoint ID of the attribute.
- * @param[in] cluster_id Cluster ID of the attribute.
- * @param[in] attribute_id Attribute ID of the attribute.
- * @param[in] val Pointer to `esp_matter_attr_val_t`. Use appropriate elements as per the value type.
- *
- * @return ESP_OK on success.
- * @return error in case of failure.
- */
+// Driver Update
+//
+// This API should be called to update the driver for the attribute being updated.
+// This is usually called from the common `app_attribute_update_cb()`.
+//
+// @param[in] endpoint_id Endpoint ID of the attribute.
+// @param[in] cluster_id Cluster ID of the attribute.
+// @param[in] attribute_id Attribute ID of the attribute.
+// @param[in] val Pointer to `esp_matter_attr_val_t`. Use appropriate elements as per the value type.
+//
+// @return ESP_OK on success.
+// @return error in case of failure.
+//
 esp_err_t app_driver_attribute_update(app_driver_handle_t driver_handle, uint16_t endpoint_id, uint32_t cluster_id,
                                       uint32_t attribute_id, esp_matter_attr_val_t *val);
-/** Force the relay off (thermal fault path).
- *
- * Used by the thermal monitor when an overtemp fault is detected. Performs
- * both a direct GPIO write to ensure the relay physically de-energizes,
- * and a Matter attribute update so connected ecosystems see the state change.
- *
- * This is a temporary shim that lives in app_driver.cpp while the relay
- * code has not yet been extracted into its own module. When relay
- * extraction is complete, this function will be removed and callers will
- * use relay_set(false) instead.
- *
- * Safe to call from any task. Does not block.
- */
- void app_driver_force_relay_off(void);
 
-/** Set defaults for light driver
- *
- * Set the attribute drivers to their default values from the created data model.
- *
- * @param[in] endpoint_id Endpoint ID of the driver.
- *
- * @return ESP_OK on success.
- * @return error in case of failure.
- */
+// Set defaults for light driver
+//
+// Set the attribute drivers to their default values from the created data model.
+//
+// @param[in] endpoint_id Endpoint ID of the driver.
+//
+// @return ESP_OK on success.
+// @return error in case of failure.
+
 esp_err_t app_driver_light_set_defaults(uint16_t endpoint_id);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/source/shelly-1-gen4/light/main/app_priv.h
+++ b/source/shelly-1-gen4/light/main/app_priv.h
@@ -44,6 +44,20 @@ app_driver_handle_t app_driver_light_init();
  */
 esp_err_t app_driver_attribute_update(app_driver_handle_t driver_handle, uint16_t endpoint_id, uint32_t cluster_id,
                                       uint32_t attribute_id, esp_matter_attr_val_t *val);
+/** Force the relay off (thermal fault path).
+ *
+ * Used by the thermal monitor when an overtemp fault is detected. Performs
+ * both a direct GPIO write to ensure the relay physically de-energizes,
+ * and a Matter attribute update so connected ecosystems see the state change.
+ *
+ * This is a temporary shim that lives in app_driver.cpp while the relay
+ * code has not yet been extracted into its own module. When relay
+ * extraction is complete, this function will be removed and callers will
+ * use relay_set(false) instead.
+ *
+ * Safe to call from any task. Does not block.
+ */
+ void app_driver_force_relay_off(void);
 
 /** Set defaults for light driver
  *

--- a/source/shelly-1-gen4/light/main/app_priv.h
+++ b/source/shelly-1-gen4/light/main/app_priv.h
@@ -29,15 +29,6 @@ typedef void *app_driver_handle_t;
  */
 app_driver_handle_t app_driver_light_init();
 
-/** Initialize the button driver
- *
- * This initializes the button driver associated with the selected board.
- *
- * @return Handle on success.
- * @return NULL in case of failure.
- */
-app_driver_handle_t app_driver_button_init();
-
 /** Driver Update
  *
  * This API should be called to update the driver for the attribute being updated.

--- a/source/shelly-1-gen4/light/main/button.cpp
+++ b/source/shelly-1-gen4/light/main/button.cpp
@@ -1,0 +1,54 @@
+#include "button.h"
+
+#include <esp_log.h>
+#include <esp_matter.h>
+#include <driver/gpio.h>
+#include <button_gpio.h>
+#include <iot_button.h>
+
+using namespace chip::app::Clusters;
+using namespace esp_matter;
+
+static const char *TAG = "button";
+
+// Defined in app_main.cpp. Used by the button callback to know which
+// Matter endpoint's OnOff attribute to toggle.
+extern uint16_t light_endpoint_id;
+
+// Shelly 1 Gen4 onboard button is on GPIO4, active low.
+#define BUTTON_GPIO         GPIO_NUM_4
+#define BUTTON_ACTIVE_LEVEL 0
+
+static void button_toggle_cb(void *arg, void *data)
+{
+    ESP_LOGI(TAG, "Toggle button pressed");
+    uint16_t endpoint_id = light_endpoint_id;
+    uint32_t cluster_id = OnOff::Id;
+    uint32_t attribute_id = OnOff::Attributes::OnOff::Id;
+
+    attribute_t *attribute = attribute::get(endpoint_id, cluster_id, attribute_id);
+    esp_matter_attr_val_t val = esp_matter_invalid(NULL);
+    attribute::get_val(attribute, &val);
+    val.val.b = !val.val.b;
+    attribute::update(endpoint_id, cluster_id, attribute_id, &val);
+}
+
+shelly_button_handle_t button_init(void)
+{
+    button_handle_t handle = NULL;
+    const button_config_t btn_cfg = {0};
+
+    const button_gpio_config_t btn_gpio_cfg = {
+        .gpio_num = BUTTON_GPIO,
+        .active_level = BUTTON_ACTIVE_LEVEL,
+    };
+
+    if (iot_button_new_gpio_device(&btn_cfg, &btn_gpio_cfg, &handle) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create button device");
+        return NULL;
+    }
+
+    iot_button_register_cb(handle, BUTTON_PRESS_DOWN, NULL, button_toggle_cb, NULL);
+    ESP_LOGI(TAG, "Button initialized on GPIO%d", BUTTON_GPIO);
+    return (shelly_button_handle_t)handle;
+}

--- a/source/shelly-1-gen4/light/main/button.h
+++ b/source/shelly-1-gen4/light/main/button.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <esp_err.h>
+
+typedef void *shelly_button_handle_t;
+
+// Initialize the device button (GPIO4 on Shelly 1 Gen4).
+//
+// Configures the onboard button as an active-low input. On press-down,
+// toggles the OnOff attribute on the light endpoint.
+//
+// The returned handle can be passed to app_reset_button_register() to
+// also wire factory-reset behavior to the same physical button.
+//
+// Returns a button handle on success, NULL on failure.
+shelly_button_handle_t button_init(void);

--- a/source/shelly-1-gen4/light/main/relay.cpp
+++ b/source/shelly-1-gen4/light/main/relay.cpp
@@ -1,0 +1,51 @@
+#include "relay.h"
+#include "thermal.h"
+
+#include <esp_log.h>
+#include <driver/gpio.h>
+
+// SAFETY: This module is the single point of relay control. See relay.h
+// for the full safety invariant and contributor convention. Briefly:
+//   - relay_init() drives the GPIO LOW immediately after configuring it
+//     as output. Do not reorder.
+//   - relay_set(true) is gated by thermal_is_faulted(). Do not bypass.
+//   - relay_set(false) is always allowed. Do not gate it.
+
+static const char *TAG = "relay";
+
+// Shelly 1 Gen4 mains-switching relay is on GPIO5, active high.
+// HIGH = energized, LOW = de-energized.
+#define RELAY_GPIO  GPIO_NUM_5
+
+esp_err_t relay_init(void)
+{
+    gpio_config_t relay_cfg = {
+        .pin_bit_mask = (1ULL << RELAY_GPIO),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&relay_cfg);
+
+    // SAFETY: Drive the relay LOW as the first action after output
+    // configuration. This enforces the safe-low boot invariant
+    // documented in relay.h.
+    gpio_set_level(RELAY_GPIO, 0);
+
+    ESP_LOGI(TAG, "Relay initialized on GPIO%d (de-energized)", RELAY_GPIO);
+    return ESP_OK;
+}
+
+esp_err_t relay_set(bool power)
+{
+    // SAFETY: Refuse turn-on while thermal lockout is active. Turn-off
+    // is always allowed. The safe direction is never blocked.
+    if (power && thermal_is_faulted()) {
+        ESP_LOGW(TAG, "Thermal fault active, relay turn-on blocked");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_LOGI(TAG, "Setting relay: %s", power ? "ON" : "OFF");
+    return gpio_set_level(RELAY_GPIO, power ? 1 : 0);
+}

--- a/source/shelly-1-gen4/light/main/relay.h
+++ b/source/shelly-1-gen4/light/main/relay.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <esp_err.h>
+#include <stdbool.h>
+
+// Relay control for the Shelly 1 Gen4 mains-switching relay (GPIO5).
+//
+// This module owns the relay GPIO and is the single point of relay
+// control in the firmware. All relay state changes from Matter
+// commands, the onboard button, the wall switch input, thermal faults,
+// or boot-time defaults go through relay_set().
+//
+// SAFETY INVARIANT
+// ----------------
+// The relay shall de-energize (drive LOW) under all conditions where
+// the firmware cannot guarantee the user's intended state:
+//
+//   1. PRE-INIT / BOOT: relay_init() drives the GPIO LOW immediately
+//      after configuring it as an output. The window between chip
+//      reset and relay_init() executing is governed by the hardware's
+//      reset state. The Shelly PCB pulls the MOSFET gate low in this
+//      window, so the relay stays de-energized.
+//
+//   2. THERMAL FAULT: the thermal monitor (thermal.cpp) calls
+//      relay_set(false) when the board exceeds 75°C sustained for 10
+//      seconds. relay_set() enforces a lockout. While thermal_is_faulted()
+//      returns true, calls to relay_set(true) are refused.
+//
+//   3. THREAD / NETWORK LOSS: the relay state is INTENTIONALLY held.
+//      Loss of Thread connectivity does not change physical state.
+//      This is by design. Users should not lose control of their
+//      lighting because of a network blip. It is not a safety failure.
+//
+//   4. UNHANDLED EXCEPTION / PANIC: the ESP32 hardware watchdog resets
+//      the chip. On the next boot, relay_init() re-enforces the
+//      safe-low invariant. The relay is briefly in its hardware
+//      reset state during the panic-to-reboot window.
+//
+// CONTRIBUTOR CONVENTION
+// ----------------------
+// Any change that touches relay control must preserve these
+// invariants. In particular:
+//   - Do not add bypass paths to relay_set() that skip the thermal
+//     lockout check.
+//   - Do not remove or reorder the safe-low GPIO drive in relay_init().
+//   - Do not add code paths that turn the relay ON without going
+//     through relay_set().
+//
+// Reviewers should reject pull requests that weaken these guarantees
+// without explicit discussion of the safety implications.
+
+// Initialize the relay subsystem. Configures GPIO5 as an output and
+// drives it LOW. Must be called once during boot, before any other
+// relay-related code runs.
+//
+// Returns ESP_OK on success, error code on failure.
+esp_err_t relay_init(void);
+
+// Set the relay state.
+//
+// power=true:  Energize the relay (close the contacts, turn the load ON).
+//              REFUSED with ESP_ERR_INVALID_STATE if thermal_is_faulted()
+//              is true.
+// power=false: De-energize the relay (open the contacts, turn the load OFF).
+//              Always allowed. Turning off is never blocked.
+//
+// Safe to call from any task. Does not block.
+//
+// Returns ESP_OK on success, ESP_ERR_INVALID_STATE if blocked by
+// thermal lockout, or error code from the underlying GPIO driver.
+esp_err_t relay_set(bool power);

--- a/source/shelly-1-gen4/light/main/switch_input.cpp
+++ b/source/shelly-1-gen4/light/main/switch_input.cpp
@@ -1,0 +1,107 @@
+#include "switch_input.h"
+
+#include <esp_log.h>
+#include <esp_matter.h>
+#include <driver/gpio.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/queue.h>
+
+using namespace chip::app::Clusters;
+using namespace esp_matter;
+
+static const char *TAG = "switch_input";
+
+// Defined in app_main.cpp. Used to know which Matter endpoint's OnOff
+// attribute to toggle when the switch input fires.
+extern uint16_t light_endpoint_id;
+
+// Shelly 1 Gen4 wall switch input.
+//
+// HARDWARE NOTE: GPIO_PULLUP_DISABLE and GPIO_PULLDOWN_DISABLE are
+// required. The Shelly PCB has an external pull resistor on GPIO10.
+// Enabling either internal pull will fight the external circuit and
+// prevent the ISR from firing. Do not "fix" this by adding a pull.
+#define SWITCH_INPUT_GPIO   GPIO_NUM_10
+#define DEBOUNCE_MS         50
+#define QUEUE_DEPTH         10
+#define TASK_STACK_SIZE     4096
+#define TASK_PRIORITY       10
+
+// ISR-to-task communication queue. Written by the ISR (FromISR),
+// read by the task. File-static so the ISR can reach it.
+static QueueHandle_t switch_evt_queue = nullptr;
+
+static void IRAM_ATTR switch_input_isr(void *arg)
+{
+    uint32_t gpio_num = SWITCH_INPUT_GPIO;
+    xQueueSendFromISR(switch_evt_queue, &gpio_num, nullptr);
+}
+
+static void switch_input_task(void *arg)
+{
+    while (true) {
+        uint32_t io_num;
+        if (xQueueReceive(switch_evt_queue, &io_num, portMAX_DELAY)) {
+            // Debounce: wait, then drain any additional events that
+            // queued during the debounce window. This collapses a noisy
+            // mechanical edge into a single logical event.
+            vTaskDelay(pdMS_TO_TICKS(DEBOUNCE_MS));
+            while (xQueueReceive(switch_evt_queue, &io_num, 0) == pdTRUE) {}
+
+            // Toggle the Matter OnOff attribute. The attribute update
+            // triggers the standard callback path which drives the
+            // relay GPIO via app_driver_relay_set_power().
+            uint16_t endpoint_id = light_endpoint_id;
+            uint32_t cluster_id = OnOff::Id;
+            uint32_t attribute_id = OnOff::Attributes::OnOff::Id;
+
+            attribute_t *attribute = attribute::get(endpoint_id, cluster_id, attribute_id);
+            esp_matter_attr_val_t val = esp_matter_invalid(nullptr);
+            attribute::get_val(attribute, &val);
+            val.val.b = !val.val.b;
+            attribute::update(endpoint_id, cluster_id, attribute_id, &val);
+            ESP_LOGI(TAG, "Switch input toggled relay");
+        }
+    }
+}
+
+esp_err_t switch_input_init(void)
+{
+    // Create the ISR-to-task communication queue and the task that
+    // services it. The task must exist before the ISR can fire
+    // (otherwise events queue up with no consumer), so we create them
+    // in this order.
+    switch_evt_queue = xQueueCreate(QUEUE_DEPTH, sizeof(uint32_t));
+    xTaskCreate(switch_input_task, "switch_input", TASK_STACK_SIZE,
+                nullptr, TASK_PRIORITY, nullptr);
+
+    // Configure GPIO10 as edge-interrupt input. See HARDWARE NOTE above
+    // for why both internal pulls are disabled.
+    gpio_config_t switch_cfg = {
+        .pin_bit_mask = (1ULL << SWITCH_INPUT_GPIO),
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_ANYEDGE,
+    };
+    gpio_config(&switch_cfg);
+
+    // Install the GPIO ISR service. ESP_ERR_INVALID_STATE means it was
+    // already installed by another module (the Matter stack or
+    // iot_button via button.cpp), which is fine — we share a single
+    // ISR service across the whole app.
+    esp_err_t isr_err = gpio_install_isr_service(0);
+    if (isr_err != ESP_OK && isr_err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "Failed to install ISR service: %d", isr_err);
+    }
+
+    esp_err_t handler_err = gpio_isr_handler_add(SWITCH_INPUT_GPIO,
+                                                  switch_input_isr, nullptr);
+    if (handler_err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to add switch ISR handler: %d", handler_err);
+    }
+
+    ESP_LOGI(TAG, "Switch input initialized on GPIO%d", SWITCH_INPUT_GPIO);
+    return ESP_OK;
+}

--- a/source/shelly-1-gen4/light/main/switch_input.cpp
+++ b/source/shelly-1-gen4/light/main/switch_input.cpp
@@ -51,7 +51,7 @@ static void switch_input_task(void *arg)
 
             // Toggle the Matter OnOff attribute. The attribute update
             // triggers the standard callback path which drives the
-            // relay GPIO via app_driver_relay_set_power().
+            // the standard callback path which drives the relay via relay_set().
             uint16_t endpoint_id = light_endpoint_id;
             uint32_t cluster_id = OnOff::Id;
             uint32_t attribute_id = OnOff::Attributes::OnOff::Id;

--- a/source/shelly-1-gen4/light/main/switch_input.cpp
+++ b/source/shelly-1-gen4/light/main/switch_input.cpp
@@ -50,8 +50,7 @@ static void switch_input_task(void *arg)
             while (xQueueReceive(switch_evt_queue, &io_num, 0) == pdTRUE) {}
 
             // Toggle the Matter OnOff attribute. The attribute update
-            // triggers the standard callback path which drives the
-            // the standard callback path which drives the relay via relay_set().
+            // triggers the standard callback path which drives the relay via relay_set().
             uint16_t endpoint_id = light_endpoint_id;
             uint32_t cluster_id = OnOff::Id;
             uint32_t attribute_id = OnOff::Attributes::OnOff::Id;

--- a/source/shelly-1-gen4/light/main/switch_input.h
+++ b/source/shelly-1-gen4/light/main/switch_input.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <esp_err.h>
+
+// Initialize the wall switch input (GPIO10 on Shelly 1 Gen4).
+//
+// Configures GPIO10 as an interrupt-driven input. On any edge (rising
+// or falling), debounces for 50ms and then toggles the Matter OnOff
+// attribute on the light endpoint.
+//
+// This implements the "Toggle" behavior expected when wiring a standard
+// wall switch to the SW terminal — every flip of the switch toggles the
+// relay state, regardless of switch position.
+//
+// HARDWARE NOTE: The Shelly 1 Gen4 PCB has an external pull resistor
+// on GPIO10. Do not enable the internal pullup or pulldown — internal
+// pulls will fight the external circuit and prevent the ISR from
+// firing. See switch_input.cpp for details.
+//
+// Returns ESP_OK on success, error code on failure.
+esp_err_t switch_input_init(void);

--- a/source/shelly-1-gen4/light/main/thermal.cpp
+++ b/source/shelly-1-gen4/light/main/thermal.cpp
@@ -1,12 +1,19 @@
-#include "thermal.h"
+#include <thermal.h>
+#include <relay.h>
 
 #include <esp_log.h>
 #include <esp_timer.h>
+#include <esp_matter.h>
 #include <driver/temperature_sensor.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
-#include <app_priv.h>
+using namespace chip::app::Clusters;
+using namespace esp_matter;
+
+// Defined in app_main.cpp. Used to know which Matter endpoint's OnOff
+// attribute to update on thermal fault.
+extern uint16_t light_endpoint_id;
 
 static const char *TAG = "thermal";
 
@@ -45,12 +52,20 @@ static void thermal_check(void)
         } else {
             int64_t elapsed = (esp_timer_get_time() / 1000) - over_temp_start_ms;
             if (elapsed >= TEMP_SUSTAINED_MS && !fault_active) {
-                ESP_LOGE(TAG, "Thermal fault! Temp: %.1f C - forcing relay off", temp);
+                ESP_LOGE(TAG, "Thermal fault, temp: %.1f C, forcing relay off", temp);
                 fault_active = true;
-                // Belt-and-suspenders: direct GPIO + Matter attribute update.
-                // Implemented in app_driver.cpp as a temporary shim while
-                // relay extraction is pending.
-                app_driver_force_relay_off();
+
+                // Belt-and-suspenders fault response.
+                // 1. Direct hardware: relay_set(false) drives the GPIO low.
+                //    Always succeeds; turn-off is never blocked.
+                // 2. Matter attribute update: so connected ecosystems see
+                //    the state change.
+                relay_set(false);
+
+                uint32_t cluster_id = OnOff::Id;
+                uint32_t attribute_id = OnOff::Attributes::OnOff::Id;
+                esp_matter_attr_val_t val = esp_matter_bool(false);
+                attribute::update(light_endpoint_id, cluster_id, attribute_id, &val);
             }
         }
     } else {

--- a/source/shelly-1-gen4/light/main/thermal.cpp
+++ b/source/shelly-1-gen4/light/main/thermal.cpp
@@ -1,0 +1,91 @@
+#include "thermal.h"
+
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <driver/temperature_sensor.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <app_priv.h>
+
+static const char *TAG = "thermal";
+
+// Trip threshold: sustained 75°C for 10 seconds.
+// Selected to be well below safe operating limits while providing
+// margin for transient peaks during high-load switching.
+#define TEMP_TRIP_CELSIUS   75.0f
+#define TEMP_SUSTAINED_MS   10000
+
+// Polling interval for the monitor task.
+#define TEMP_POLL_INTERVAL_MS 2000
+
+// Stack size for the monitor task. Small — only does sensor reads and
+// occasional logging.
+#define THERMAL_TASK_STACK_SIZE 2048
+
+// Internal state.
+static temperature_sensor_handle_t temp_sensor = NULL;
+static int64_t over_temp_start_ms = 0;
+static volatile bool fault_active = false;
+
+static void thermal_check(void)
+{
+    float temp = 0;
+    esp_err_t err = temperature_sensor_get_celsius(temp_sensor, &temp);
+    if (err != ESP_OK) {
+        return;
+    }
+
+    ESP_LOGD(TAG, "Board temp: %.1f C", temp);
+
+    if (temp > TEMP_TRIP_CELSIUS) {
+        // Above threshold. Start timing if we haven't already.
+        if (over_temp_start_ms == 0) {
+            over_temp_start_ms = esp_timer_get_time() / 1000;
+        } else {
+            int64_t elapsed = (esp_timer_get_time() / 1000) - over_temp_start_ms;
+            if (elapsed >= TEMP_SUSTAINED_MS && !fault_active) {
+                ESP_LOGE(TAG, "Thermal fault! Temp: %.1f C - forcing relay off", temp);
+                fault_active = true;
+                // Belt-and-suspenders: direct GPIO + Matter attribute update.
+                // Implemented in app_driver.cpp as a temporary shim while
+                // relay extraction is pending.
+                app_driver_force_relay_off();
+            }
+        }
+    } else {
+        // Back below threshold. Clear timing and fault state.
+        over_temp_start_ms = 0;
+        fault_active = false;
+    }
+}
+
+static void thermal_monitor_task(void *arg)
+{
+    while (true) {
+        thermal_check();
+        vTaskDelay(pdMS_TO_TICKS(TEMP_POLL_INTERVAL_MS));
+    }
+}
+
+esp_err_t thermal_init(void)
+{
+    temperature_sensor_config_t temp_cfg = {
+        .range_min = 20,
+        .range_max = 100,
+    };
+    temperature_sensor_install(&temp_cfg, &temp_sensor);
+    temperature_sensor_enable(temp_sensor);
+
+    xTaskCreate(thermal_monitor_task, "thermal_monitor",
+                THERMAL_TASK_STACK_SIZE, NULL, 5, NULL);
+
+    ESP_LOGI(TAG, "Thermal monitor initialized (trip: %.1f C sustained %dms)",
+             TEMP_TRIP_CELSIUS, TEMP_SUSTAINED_MS);
+    return ESP_OK;
+}
+
+bool thermal_is_faulted(void)
+{
+    return fault_active;
+}

--- a/source/shelly-1-gen4/light/main/thermal.cpp
+++ b/source/shelly-1-gen4/light/main/thermal.cpp
@@ -1,5 +1,5 @@
-#include <thermal.h>
-#include <relay.h>
+#include "thermal.h"
+#include "relay.h"
 
 #include <esp_log.h>
 #include <esp_timer.h>

--- a/source/shelly-1-gen4/light/main/thermal.h
+++ b/source/shelly-1-gen4/light/main/thermal.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <esp_err.h>
+#include <stdbool.h>
+
+// Initialize the thermal monitor.
+//
+// Configures the ESP32-C6 internal temperature sensor and spawns a
+// background task that polls the temperature every 2 seconds. If the
+// board temperature exceeds 75°C sustained for 10 seconds, the thermal
+// monitor will:
+//   1. Force the relay off (via app_driver_force_relay_off)
+//   2. Update the Matter OnOff attribute to reflect the off state
+//   3. Set the thermal fault flag, blocking further relay-on commands
+//      until temperature returns to a safe range.
+//
+// The thermal fault flag automatically clears when temperature drops
+// back below 75°C (no manual reset needed).
+//
+// Returns ESP_OK on success, error code on failure.
+esp_err_t thermal_init(void);
+
+// Returns true if the thermal monitor has tripped and is currently
+// blocking relay activation. Used by relay control code to refuse
+// turn-on requests while overtemp.
+//
+// Safe to call from any task.
+bool thermal_is_faulted(void);

--- a/source/shelly-1-gen4/light/main/thermal.h
+++ b/source/shelly-1-gen4/light/main/thermal.h
@@ -9,7 +9,7 @@
 // background task that polls the temperature every 2 seconds. If the
 // board temperature exceeds 75°C sustained for 10 seconds, the thermal
 // monitor will:
-//   1. Force the relay off (via app_driver_force_relay_off)
+//   1. Drive the relay off (via relay_set(false))
 //   2. Update the Matter OnOff attribute to reflect the off state
 //   3. Set the thermal fault flag, blocking further relay-on commands
 //      until temperature returns to a safe range.


### PR DESCRIPTION
Extracts button, thermal, switch input, and relay code from app_driver.cpp into named modules with documented public interfaces. Foundation for upcoming device type variants (switch, light-switch, future Shelly Gen4 products).

### **Runtime behavior changes**

This refactor isn't strictly behavior-preserving. Three real changes worth noting:

1. **Initialization timing**. Subsystem inits (relay, thermal, switch input, button) now run in app_main() before esp_matter::start(), rather than inside app_driver_light_init() which was called after Matter started. The relay reaches its documented safe-low state ~1-2s earlier in boot, and thermal protection is active before the Matter stack initializes. The Shelly PCB pulls the MOSFET gate low in the pre-init window regardless, so this is a strengthened contract; not a fix for an observable bug.

2. **Log tags**. Each module now logs under its own tag (relay, thermal, switch_input, button, status_led) rather than the consolidated tags used in v1.2.0. Boot logs and runtime logs are now scannable by subsystem. Anyone parsing serial logs programmatically will see different prefixes.

3. **Relay safety**. Relay GPIO behavior is functionally unchanged, but the safety invariant (pre-init safe-low, thermal lockout, Thread-loss intentional hold, panic recovery) is now a documented contract in relay.h. Single point of enforcement at relay_set(). Any future variant must preserve this contract unless discussed first.

### **Unchanged**

- Matter device type, endpoint structure, cluster set
- GPIO pin assignments (4 button, 5 relay, 10 switch, 15 LED)
- Active-high relay polarity (HIGH = energized, LOW = de-energized)
- Safety thresholds (75°C / 10s sustained)
- Debounce timing (50ms)
- LED blink patterns and state machine
- Button, switch input, and Matter command toggle behavior
- Factory reset behavior
- NVS schema - existing commissioned devices upgrade in place confirmed.
- StartUpOnOff handling (via esp-matter's standard on_off_light implementation)

### **New modules**

button, thermal, switch_input, relay

### **Extraction order**

Risk-first order:

1. button (simplest, to learn extraction pattern)
2. thermal (introduces relay, thermal dependency)
3. switch_input (ISR pattern)
4. relay last with documented safety invariant. 

Each commit was independently verified on hardware before the next. Final cleanup commits fix a duplicated comment in switch_input, normalize includes in thermal, and normalize indentation + remove a stale version reference in app_main.

### **Verified on hardware**

Fresh erase + flash + commission verification cycle:

- Module init sequence in correct safety order (status_led, relay, thermal, switch_input, button)
- Fresh commissioning to Home Assistant
- Multi-admin commissioning to Apple Home
- Power-cycle persistence: both fabrics retrieved from storage, device boots directly to Thread without re-advertising
- Matter command toggle (HA): relay: Setting relay: ON/OFF routes through relay_set()
- Physical button toggle: button: Toggle button pressed, relay: Setting relay
- Wall switch input toggle: switch_input: Switch input toggled relay, relay: Setting relay
- Identify command: LED state saved, restored on stop
- Thread routing role escalation (child to router) during session
- Relay polarity confirmed: relay_set(true) drives GPIO5 HIGH (energized), relay_set(false) drives LOW (de-energized)
- StartUpOnOff attribute behavior verified across power cycles

### **Merge strategy**

Create a merge commit to preserve individual verified commits in main's history. Each refactor commit is independently revertable if a regression is discovered later.

### **Release plan**

To be released as v1.2.1 after a brief operational period on my daily driver Shelly 1 Gen4 running 12V lighting in real world Sprinter van use.