### PR TITLE
chore(build): bump ESP-Matter pin to release/v1.6

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -19,7 +19,7 @@ This guide covers building the Automatous firmware from source. If you just want
 
 ## Requirements
 
-- **ESP-IDF v5.5.2**, Espressif's IoT development framework.
+- **ESP-IDF v5.5.5**, Espressif's IoT development framework.
 - **ESP-Matter**, Espressif's Matter SDK, installed as a cloned repository. The build reads it through the `ESP_MATTER_PATH` environment variable, which esp-matter's `export.sh` sets. It is not pulled from the component registry. Check it out to the pinned commit below rather than building against `main`.
 - **macOS or Linux**. The Windows build path is not currently tested.
 
@@ -27,9 +27,9 @@ These binaries are built against pinned toolchain versions. Newer versions may b
 
 | Component | Version |
 |---|---|
-| ESP-IDF | `v5.5.2` |
-| ESP-Matter | `2cb668c95de4f24786d20b7cb03c171d6e27b79e` |
-| connectedhomeip (esp-matter submodule) | `8f943388af4d12dc5c484eae21b22723e03c3616` |
+| ESP-IDF | `v5.5.5` |
+| ESP-Matter | `36c2634e99c884830897e2b9501e2d9a6c9d60fd` |
+| connectedhomeip (esp-matter submodule) | `d46cc8c2886cbefc338544bdb2e2f8128f3e9970` |
 
 connectedhomeip is a submodule of esp-matter, so checking out the esp-matter commit and updating its submodules pulls the matching connectedhomeip commit automatically. It lives in Espressif's connectedhomeip fork, not the upstream CSA repository.
 
@@ -58,7 +58,7 @@ Each variant is a self-contained ESP-IDF project. Build commands run from inside
 
 If you don't already have ESP-IDF and ESP-Matter installed, follow Espressif's official setup guides first:
 
-- [ESP-IDF Get Started](https://docs.espressif.com/projects/esp-idf/en/v5.5.2/esp32c6/get-started/index.html)
+- [ESP-IDF Get Started](https://docs.espressif.com/projects/esp-idf/en/v5.5.5/esp32c6/get-started/index.html)
 - [ESP-Matter Get Started](https://docs.espressif.com/projects/esp-matter/en/latest/esp32c6/developing.html)
 
 This project assumes you have both SDKs installed. The build step below sets the ESP32-C6 target.
@@ -67,7 +67,7 @@ After cloning esp-matter, check it out to the pinned commit and sync its submodu
 
 ```bash
 cd ~/esp/esp-matter
-git checkout 2cb668c95de4f24786d20b7cb03c171d6e27b79e
+git checkout 36c2634e99c884830897e2b9501e2d9a6c9d60fd
 git submodule update --init --recursive
 ```
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -71,6 +71,16 @@ git checkout 36c2634e99c884830897e2b9501e2d9a6c9d60fd
 git submodule update --init --recursive
 ```
 
+connectedhomeip's GN build needs a generated `build_overrides/pigweed_environment.gni`, which is not checked into the repo. Run its environment bootstrap once per esp-matter checkout to create it:
+
+```bash
+cd connectedhomeip/connectedhomeip
+scripts/bootstrap.sh
+cd ../..
+```
+
+Skipping this step fails the build at the `chip_gn` configure step with `Unable to load ".../build_overrides/pigweed_environment.gni"`.
+
 ---
 
 ## Build

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -19,7 +19,7 @@ This guide covers building the Automatous firmware from source. If you just want
 
 ## Requirements
 
-- **ESP-IDF v5.5.5**, Espressif's IoT development framework.
+- **ESP-IDF v5.5.4**, Espressif's IoT development framework.
 - **ESP-Matter**, Espressif's Matter SDK, installed as a cloned repository. The build reads it through the `ESP_MATTER_PATH` environment variable, which esp-matter's `export.sh` sets. It is not pulled from the component registry. Check it out to the pinned commit below rather than building against `main`.
 - **macOS or Linux**. The Windows build path is not currently tested.
 
@@ -27,7 +27,7 @@ These binaries are built against pinned toolchain versions. Newer versions may b
 
 | Component | Version |
 |---|---|
-| ESP-IDF | `v5.5.5` |
+| ESP-IDF | `v5.5.4` |
 | ESP-Matter | `36c2634e99c884830897e2b9501e2d9a6c9d60fd` |
 | connectedhomeip (esp-matter submodule) | `d46cc8c2886cbefc338544bdb2e2f8128f3e9970` |
 
@@ -58,7 +58,7 @@ Each variant is a self-contained ESP-IDF project. Build commands run from inside
 
 If you don't already have ESP-IDF and ESP-Matter installed, follow Espressif's official setup guides first:
 
-- [ESP-IDF Get Started](https://docs.espressif.com/projects/esp-idf/en/v5.5.5/esp32c6/get-started/index.html)
+- [ESP-IDF Get Started](https://docs.espressif.com/projects/esp-idf/en/v5.5.4/esp32c6/get-started/index.html)
 - [ESP-Matter Get Started](https://docs.espressif.com/projects/esp-matter/en/latest/esp32c6/developing.html)
 
 This project assumes you have both SDKs installed. The build step below sets the ESP32-C6 target.


### PR DESCRIPTION
## What

Moves the pinned ESP-Matter commit from the v1.4-era commit `2cb668c9` (Apr 2026) to `release/v1.6` HEAD as of 2026-08-06 (`36c2634e`), pulling in connectedhomeip `d46cc8c2` and requiring ESP-IDF v5.5.5.

| Component | Before | After |
|---|---|---|
| ESP-IDF | `v5.5.2` | `v5.5.5` |
| ESP-Matter | `2cb668c9` (24 Apr 2026) | `36c2634e` (release/v1.6 HEAD, 6 Aug 2026) |
| connectedhomeip | `8f943388` | `d46cc8c2` (17 Jul 2026) |

## Build status

**Build verified** for the `light` variant, against ESP-IDF v5.5.4 (closest available locally to the recommended v5.5.5) + esp-matter `36c2634e` / connectedhomeip `d46cc8c2`:

```
light.bin binary size 0x1a2dd0 bytes. Smallest app partition is 0x300000 bytes. 0x15d230 bytes (45%) free.
Project build complete.
```

No build errors. One benign Kconfig warning (`SEC_CERT_DAC_PROVIDER` defined in both `connectedhomeip/config/esp32/components/chip/Kconfig` and `esp_matter/Kconfig`, no functional effect).

Note: getting to a clean build required running connectedhomeip's `scripts/bootstrap.sh` (`pw_env_setup`) once to generate `build_overrides/pigweed_environment.gni` — not currently called out in this repo's setup docs. Worth a follow-up doc note regardless of this PR's outcome.

## Hardware verification

Flashed and exercised on a Seeed XIAO ESP32C6 (ESP32-C6FH4, 4MB flash) standing in for the Shelly board, using a local test-only 4MB partition table (not part of this PR; the real Shelly variants keep their 8MB layout unchanged). Results, all against `release/v1.6`:

- Clean boot, no panics/resets, Matter + Thread stack initialize correctly
- Full commissioning flow succeeded: PASE → CASE → AddNOC → `Commissioning completed successfully`, device joined the Thread mesh (`child` → `router`)
- Application logic: physical button press → `OnOff` attribute (endpoint 1) toggled → relay driver logs `Setting relay: ON`
- **Matter OTA update, end to end**: built and served a `v2.1.1` `.ota` against the already-commissioned `v2.1.0` device via this project's own OTA provider. Watched the BDX block transfer complete over Thread, device rebooted, and post-update read of Basic Information's `SoftwareVersionString` (attribute 0x000A) confirmed `"2.1.1"`.
- **Groups cluster**: reconfigured the device's group membership via Home Assistant. Serial log shows clean `InvokeCommandRequest` → `Leaving Multicast Group with address UDP:[ff35:40:fd00::200:1]:5540` → `InvokeCommandResponse`, then the same pattern joining group 2's multicast address — no error status anywhere in the exchange. The "code driven" Groups cluster rewrite (see below) processes membership changes and updates the underlying Thread multicast group join/leave correctly.

**Not yet covered:**
- Only the `light` variant was built/flashed. `outlet`, `opener`, `light-switch`, and the Mini `outlet` variant share the same base and are expected to behave the same way, but weren't individually verified.

## Groups cluster rewrite (context, now verified)

connectedhomeip migrated the Groups cluster server to the "code driven" architecture in this commit range (espressif/connectedhomeip#42851, #42886) — a full reimplementation, not incremental patches. The cluster revision was bumped to 5 then rolled back to 4 (#71572). The hardware test above exercised group add/remove through this new implementation and it behaved correctly.

## Related

- #30 — follow-up to evaluate/adopt Matter 1.6 spec features this bump unlocks
- #31 — unrelated finding from this test pass: `SerialNumber` is always empty; proposes populating it from the MAC address